### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = "ruby lib/hangman.rb"

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ You get six guesses before it is game over. The game allows you to save your cur
 
 ## Reflection
 This project was created to practice manipulating files and serialization. I chose to serialize the game in the Marshal format as the information within the saved game doesn't need to be human readbale.
+
+[![Run on Repl.it](https://repl.it/badge/github/RichardDenton/hangman)](https://repl.it/github/RichardDenton/hangman)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).